### PR TITLE
fix 401 error in the console when fetching the manifest.json

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->

There's a CORS issue when trying to open a browser window for the default set up, and the current recommended best practice is to use the `crossorigin="use-credentials"` attribute for this:

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#example_webmanifest_with_credentials

![401 error](https://user-images.githubusercontent.com/5070516/145675624-e6f65e24-58ad-46aa-ae58-b4c6863a42f5.png)


## How to test
<!-- Provide steps to test this PR -->

Run the template in a gitpod and check the developer console in the browser.


<a href="https://gitpod.io/#https://github.com/gitpod-io/template-typescript-react/pull/5"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

