### PR TITLE
Add WebStorm prebuild config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 # Learn more about this file at https://www.gitpod.io/docs/references/gitpod-yml
 tasks:
   - init: yarn
-  - command: yarn start
+    command: yarn start
 ports:
   - port: 3000
     onOpen: open-preview
@@ -21,3 +21,7 @@ github:
     addComment: false
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
     addBadge: true
+jetbrains:
+  webstorm:
+    prebuilds:
+      version: both


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now that https://github.com/gitpod-io/gitpod/pull/13612 has been merged, we can use [prebuilds](https://www.gitpod.io/docs/configure/projects/prebuilds) in this repository.

<a href="https://gitpod.io/#https://github.com/gitpod-io/template-typescript-react/pull/13"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

